### PR TITLE
fix for performance loss on CUDA > 11.0

### DIFF
--- a/src/modules/dslash/dslash.cpp
+++ b/src/modules/dslash/dslash.cpp
@@ -13,7 +13,7 @@ __host__ __device__ auto HisqDslashFunctor<floatT, LatLayoutRHS, HaloDepthGauge,
     typedef GIndexer<LayoutSwitcher<LatLayoutRHS>(), HaloDepthSpin> GInd;
 
     gVect3<floatT> Stmp(0.0);
-
+#pragma unroll    
     for (int mu = 0; mu < 4; mu++) {
 
         Stmp += static_cast<floatT>(C_1000) * _gAcc_smeared.getLink(
@@ -38,7 +38,6 @@ __host__ __device__ auto HisqMdaggMFunctor<floatT, LatLayoutRHS, HaloDepthGauge,
     typedef GIndexer<LayoutSwitcher<LatLayoutRHS>(), HaloDepthSpin> GInd;
 
     gVect3<floatT> Stmp(0.0);
-
     for (int mu = 0; mu < 4; mu++) {
 
         Stmp += static_cast<floatT>(C_1000) * _gAcc_smeared.getLink(


### PR DESCRIPTION
Found a fix to the performance loss on CUDA versions > 11.0

It is actually embarrassingly simple...

Just a #pragma unroll in the Dslash