### PR TITLE
fix a bug in ildg conf reader and add stabilized Wilson fermion confs…

### DIFF
--- a/src/applications/main_CheckConf.cpp
+++ b/src/applications/main_CheckConf.cpp
@@ -50,7 +50,9 @@ void CheckConf(CommunicationBase &commBase, const std::string& format, std::stri
     } else if (format == "ildg") {
         gauge.readconf_ildg(Gaugefile);
     } else if (format == "milc") {
-        gauge.readconf_milc(Gaugefile);
+        gauge.readconf_milc(Gaugefile); 
+    } else if (format == "openqcd") {
+        gauge.readconf_openqcd(Gaugefile);
     } else {
         throw (std::runtime_error(rootLogger.fatal("Invalid specification for format ", format)));
     }
@@ -58,7 +60,7 @@ void CheckConf(CommunicationBase &commBase, const std::string& format, std::stri
 
     GaugeAction<floatT, false, HaloDepth> gaugeAction(gauge);
     floatT plaq = gaugeAction.plaquette();
-    rootLogger.info("Plaquette = ", plaq);
+    rootLogger.info("Plaquette = ", plaq * 3);
     if ( (plaq > 1.0) || (plaq < 0.0) ) {
         throw std::runtime_error(rootLogger.fatal("Plaquette should not be negative or larger than 1."));
     }

--- a/src/applications/main_gradientFlow.cpp
+++ b/src/applications/main_gradientFlow.cpp
@@ -361,8 +361,17 @@ void run(CommunicationBase &commBase, gradientFlowParam<floatT> &lp) {
         rootLogger.info("Using unit configuration for tests/benchmarks");
         gauge.one();
     } else {
-        rootLogger.info("Read configuration");
-        gauge.readconf_nersc(lp.GaugefileName());
+        if (lp.format() == "nersc") {
+            gauge.readconf_nersc(lp.GaugefileName());
+        } else if (lp.format() == "ildg") {
+            gauge.readconf_ildg(lp.GaugefileName());
+        } else if (lp.format() == "milc") {
+            gauge.readconf_milc(lp.GaugefileName()); 
+        } else if (lp.format() == "openqcd") {
+            gauge.readconf_openqcd(lp.GaugefileName());
+        } else {
+            throw (std::runtime_error(rootLogger.fatal("Invalid specification for format ", lp.format())));
+        }
     }
     gauge.updateAll();
 

--- a/src/gauge/gaugefield.h
+++ b/src/gauge/gaugefield.h
@@ -66,6 +66,10 @@ public:
 
     void readconf_milc_host(gaugeAccessor<floatT,comp> gaugeAccessor, const std::string &fname);
 
+    /// read in a OPENQCD file
+    void readconf_openqcd(const std::string &fname);
+
+    void readconf_openqcd_host(gaugeAccessor<floatT,comp> gaugeAccessor, const std::string &fname);
 
     /// write gaugefield to NERSC file
     void writeconf_nersc(const std::string &fname, int rows = 2,


### PR DESCRIPTION
It was hardcoded to read the nersc conf when reading the ildg conf in the gradient flow application.
Added "if else" for all supported formats to src/application/main_gradientFlow.cpp.
But still there is checksum error when reading ildg conf.
Also, a stabilized Wilson Fermion (openqcd) reader has been implemented.
There are no checksum errors in this format.