### PR TITLE
Avoid building with GPU relocatable code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,11 +157,11 @@ if (USE_CUDA)
         "${CMAKE_CUDA_FLAGS} -O3 -Wno-deprecated-gpu-targets --std=c++17 -arch=sm_${ARCHITECTURE} -Xcudafe --display_error_number -prec-div=true -prec-sqrt=true --expt-relaxed-constexpr")
 
 elseif (USE_HIP_AMD)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -Wextra -Wno-comment -Wno-deprecated-copy-with-user-provided-copy -fPIC -fgpu-rdc")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -Wextra -Wno-comment -Wno-deprecated-copy -fPIC")
 
     add_definitions(-D__HIP_PLATFORM_AMD__)
-    set(HIP_HIPCC_FLAGS ${HIP_HIPCC_FLAGS} "-O3 -std=c++17 -D__HIP_PLATFORM_AMD__ --offload-arch=${ARCHITECTURE} -fgpu-rdc")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O3 -fgpu-rdc --hip-link --craype-prepend-opt=-Wl,-rpath=${ROCM_PATH}/deps")
+    set(HIP_HIPCC_FLAGS ${HIP_HIPCC_FLAGS} "-O3 -std=c++17 -D__HIP_PLATFORM_AMD__ --offload-arch=${ARCHITECTURE}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O3")
 
 elseif (USE_HIP_NVIDIA)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -Wextra -Wno-comment -fPIC")

--- a/src/base/indexer/bulkIndexer.h
+++ b/src/base/indexer/bulkIndexer.h
@@ -290,7 +290,17 @@ struct LatticeData {
 
 
 };
-extern __device__ __constant__ struct LatticeData globLatDataGPU[MAXHALO + 1];
+
+// To avoid using relocatable code builds, we use static instances of the GPU constant memory for the Lattice data.
+// This means that each compilation unit will use its own. To make sure all instances are initialized with the same
+// address, we use the Ctor of a static object to register all intances so that the initialization
+// could be copied to all of them.
+__device__ __constant__ struct LatticeData globLatDataGPU[MAXHALO + 1];
+struct globLatDataRegistor {
+    globLatDataRegistor(LatticeData &);
+};
+static globLatDataRegistor globLatDataRegistorInstance(globLatDataGPU[0]);
+
 extern struct LatticeData globLatDataCPU[MAXHALO + 1];
 
 /// --------------------------------------------------------------------------------------------- INDEXER INITIALIZATION

--- a/src/base/indexer/haloIndexer.h
+++ b/src/base/indexer/haloIndexer.h
@@ -268,9 +268,17 @@ private:
 
 };
 
+// To avoid using relocatable code builds, we use static instances of the GPU constant memory for the Halo data.
+// This means that each compilation unit will use its own. To make sure all instances are initialized with the same
+// address, we use the Ctor of a static object to register all intances so that the initialization
+// could be copied to all of them.
+__device__ __constant__ struct HaloData globHalDataGPU[MAXHALO + 1];
+__device__ __constant__ struct HaloData globHalDataGPUReduced[MAXHALO + 1];
+struct globHalDataRegistor {
+    globHalDataRegistor(HaloData &, HaloData &);
+};
+static globHalDataRegistor globHalDataRegistorInstance(globHalDataGPU[0], globHalDataGPUReduced[0]);
 
-extern __device__ __constant__ struct HaloData globHalDataGPU[MAXHALO + 1];
-extern __device__ __constant__ struct HaloData globHalDataGPUReduced[MAXHALO + 1];
 extern struct HaloData globHalDataCPU[MAXHALO + 1];
 extern struct HaloData globHalDataCPUReduced[MAXHALO + 1];
 

--- a/src/base/indexer/initGPUIndexer.cpp
+++ b/src/base/indexer/initGPUIndexer.cpp
@@ -9,8 +9,21 @@
 #include "bulkIndexer.h"
 #include "../indexer/haloIndexer.h"
 
+// We record the set of constant memory symbols to static arrays. We are avoiding using objects with non-trivial Ctors
+// to not risk they to be constructed after the static object that uses them. There will be an instance of the static
+// objects per compilation unit, so the ordering is hard to control.
+static const size_t globLatDataRegisterSize = 16;
+static LatticeData* globLatDataGPURegister[globLatDataRegisterSize] = {0};
+globLatDataRegistor::globLatDataRegistor(LatticeData &v) {
+   for (size_t InstanceIdx = 0; InstanceIdx < globLatDataRegisterSize; ++InstanceIdx)
+      if (LatticeData *& slot = globLatDataGPURegister[InstanceIdx]; !slot) {
+         slot = &v;
+         printf("Got instance of globLatData handler %p (index %ld)\n", &v, InstanceIdx);
+         return;
+      }
 
-__device__ __constant__ struct LatticeData globLatDataGPU[MAXHALO+1];
+   assert(false && "Not enough slots to register globLatData slots.");
+}
 
 void initGPUBulkIndexer(size_t lx, size_t ly, size_t lz, size_t lt, sitexyzt globCoord, sitexyzt globPos,unsigned int Nodes[4]){
 
@@ -24,18 +37,42 @@ void initGPUBulkIndexer(size_t lx, size_t ly, size_t lz, size_t lt, sitexyzt glo
                 globPos.x,globPos.y,globPos.z,globPos.t);
     }
 
-    gpuErr = gpuMemcpyToSymbol(globLatDataGPU, &latDat, sizeof(LatticeData[MAXHALO+1]), 0, gpuMemcpyHostToDevice);
-    if (gpuErr)
-        GpuError("Failed to send LatticeData to device", gpuErr);
+    for (size_t InstanceIdx = 0; InstanceIdx < globLatDataRegisterSize; ++InstanceIdx)
+      if (auto* slot = globLatDataGPURegister[InstanceIdx]; slot ) {
 
-    gpuErr = gpuDeviceSynchronize();
-    if (gpuErr)
-        GpuError("initGPUBulkIndexer: gpuDeviceSynchronize failed", gpuErr);
+        printf("Setting globLatData handler %p (index %ld)\n", slot, InstanceIdx);
+
+        gpuErr = gpuMemcpyToSymbol(*slot, &latDat, sizeof(LatticeData[MAXHALO+1]), 0, gpuMemcpyHostToDevice);
+        if (gpuErr)
+            GpuError("Failed to send LatticeData to device", gpuErr);
+
+        gpuErr = gpuDeviceSynchronize();
+        if (gpuErr)
+            GpuError("initGPUBulkIndexer: gpuDeviceSynchronize failed", gpuErr);
+      } else
+         break;
+
+    printf("Done setting all instances of device LatticeData handlers!\n");
 }
 
+// We record the set of constant memory symbols to static arrays. We are avoiding using objects with non-trivial Ctors
+// to not risk they to be constructed after the static object that uses them. There will be an instance of the static
+// objects per compilation unit, so the ordering is hard to control.
+static const size_t globHalDataRegisterSize = 16;
+static HaloData* globHalDataGPURegister[globHalDataRegisterSize] = {0};
+static HaloData* globHalDataGPUReducedRegister[globHalDataRegisterSize] = {0};
+globHalDataRegistor::globHalDataRegistor(HaloData &v1, HaloData &v2) {
+   for (size_t InstanceIdx = 0; InstanceIdx < globHalDataRegisterSize; ++InstanceIdx)
+      if (HaloData *&slot1 = globHalDataGPURegister[InstanceIdx], 
+                   *&slot2 = globHalDataGPUReducedRegister[InstanceIdx]; !slot1 && !slot2) {
+         slot1 = &v1;
+         slot2 = &v2;
+         printf("Got instances of globHalData handler %p, %p (index %ld)\n", &v1, &v2, InstanceIdx);
+         return;
+      }
 
-__device__ __constant__ struct HaloData globHalDataGPU[MAXHALO+1];
-__device__ __constant__ struct HaloData globHalDataGPUReduced[MAXHALO+1];
+   assert(false && "Not enough slots to register globHalData slots.");
+}
 
 void initGPUHaloIndexer(size_t lx, size_t ly, size_t lz, size_t lt, unsigned int Nodes[4], unsigned int Halos[4]) {
 
@@ -48,17 +85,27 @@ void initGPUHaloIndexer(size_t lx, size_t ly, size_t lz, size_t lt, unsigned int
         halDatReduced[i] = HaloData(lx-2*Halos[0],ly-2*Halos[1],lz-2*Halos[2],lt-2*Halos[3],i,Nodes);
     }
 
-    gpuErr = gpuMemcpyToSymbol(globHalDataGPU, &halDat, sizeof(HaloData[MAXHALO+1]), 0, gpuMemcpyHostToDevice);
-    if (gpuErr)
-        GpuError("Failed to send HaloData to device", gpuErr);
-    gpuErr = gpuDeviceSynchronize();
-    if (gpuErr)
-        GpuError("initGPUHaloIndexer: gpuDeviceSynchronize failed (1)", gpuErr);
+    for (size_t InstanceIdx = 0; InstanceIdx < globHalDataRegisterSize; ++InstanceIdx)
+      if (auto *slot1 = globHalDataGPURegister[InstanceIdx],
+               *slot2 = globHalDataGPUReducedRegister[InstanceIdx]; slot1 && slot2 ) {
 
-    gpuErr = gpuMemcpyToSymbol(globHalDataGPUReduced, &halDatReduced, sizeof(HaloData[MAXHALO+1]), 0, gpuMemcpyHostToDevice);
-    if (gpuErr)
-        GpuError("Failed to send HaloData to device", gpuErr);
-    gpuErr = gpuDeviceSynchronize();
-    if (gpuErr)
-        GpuError("initGPUHaloIndexer: gpuDeviceSynchronize failed (2)", gpuErr);
+        printf("Setting globHalData handler %p, %p (index %ld)\n", slot1, slot2, InstanceIdx);
+
+        gpuErr = gpuMemcpyToSymbol(*slot1, &halDat, sizeof(HaloData[MAXHALO+1]), 0, gpuMemcpyHostToDevice);
+        if (gpuErr)
+            GpuError("Failed to send HaloData to device", gpuErr);
+        gpuErr = gpuDeviceSynchronize();
+        if (gpuErr)
+            GpuError("initGPUHaloIndexer: gpuDeviceSynchronize failed (1)", gpuErr);
+
+        gpuErr = gpuMemcpyToSymbol(*slot2, &halDatReduced, sizeof(HaloData[MAXHALO+1]), 0, gpuMemcpyHostToDevice);
+        if (gpuErr)
+            GpuError("Failed to send HaloData to device", gpuErr);
+        gpuErr = gpuDeviceSynchronize();
+        if (gpuErr)
+            GpuError("initGPUHaloIndexer: gpuDeviceSynchronize failed (2)", gpuErr);    
+      } else
+         break;
+
+    printf("Done setting all instances of device HaloData handlers!\n");
 }

--- a/src/spinor/spinorfield.h
+++ b/src/spinor/spinorfield.h
@@ -98,6 +98,8 @@ typedef floatT floatT_inner;
     //! destructor
     ~Spinorfield() {
         gpuError_t gpuErr = gpuStreamDestroy(runStream);
+        if (gpuErr)
+            GpuError("Failed to destroy stream", gpuErr);
     };
 
     Spinorfield<floatT, onDevice, LatticeLayout, HaloDepth, NStacks> &


### PR DESCRIPTION
This PR disables relocatable code builds for the GPU. This is done at the expense of more memory usage as the contant memory entities are replicated by compilation unit. In turn this enables faster builds as it avoids the serialized GPU codegen at link time. 

The hope is to enable faster build times for development/testing without disruptive changes. This can be of interest to others  (or not).