### PR TITLE
Marker and timing updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,6 +483,12 @@ set_SIMULATeQCD_property(colorElectricCorrTest PROPERTIES RUNTIME_OUTPUT_DIRECTO
 SIMULATeQCD_target_compile_definitions(colorElectricCorrTest PRIVATE HALODEPTH_1=1 DOUBLEPREC=1 COMP_R18=1)
 add_to_compound_SIMULATeQCD_target(tests colorElectricCorrTest)
 
+set_SIMULATeQCD_gpu_backend(src/testing/main_stopwatch.cpp)
+add_SIMULATeQCD_executable(stopwatchTest src/testing/main_stopwatch.cpp)
+set_SIMULATeQCD_property(stopwatchTest PROPERTIES RUNTIME_OUTPUT_DIRECTORY "testing")
+SIMULATeQCD_target_compile_definitions(stopwatchTest PRIVATE HALODEPTH_1=1)
+add_to_compound_SIMULATeQCD_target(tests stopwatchTest)
+
 set_SIMULATeQCD_gpu_backend(src/testing/main_compressionTest.cpp)
 add_SIMULATeQCD_executable(compressionTest src/testing/main_compressionTest.cpp)
 set_SIMULATeQCD_property(compressionTest PROPERTIES RUNTIME_OUTPUT_DIRECTORY "testing")

--- a/src/base/IO/logging.h
+++ b/src/base/IO/logging.h
@@ -21,8 +21,8 @@
 #include "stringFunctions.h"
 
 
-enum LogLevel { ALL, ALLOC, TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF };
-static const char *LogLevelStr[] = {"ALL",  "ALLOC", "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL", "OFF"};
+enum LogLevel { ALL, ALLOC, TRACE, TIME, DEBUG, INFO, WARN, ERROR, FATAL, OFF };
+static const char *LogLevelStr[] = {"ALL",  "ALLOC", "TRACE", "TIME", "DEBUG", "INFO", "WARN", "ERROR", "FATAL", "OFF"};
 
 class Logger {
 private:
@@ -103,6 +103,9 @@ public:
     };
     template <typename... Args> inline std::string trace(Args&&... args) {
         return message<TRACE>(std::forward<Args>(args)...);
+    };
+    template <typename... Args> inline std::string time(Args&&... args) {
+        return message<TIME>(std::forward<Args>(args)...);
     };
     template <typename... Args> inline std::string alloc(Args&&... args) {
         return message<ALLOC>(std::forward<Args>(args)...);

--- a/src/base/runFunctors.h
+++ b/src/base/runFunctors.h
@@ -11,7 +11,7 @@
 #include "../base/gutils.h"
 #include "math/operators.h"
 #include "../base/communication/communicationBase.h"
-#include "../base/utilities/parseObjectName.h"
+// #include "../base/utilities/parseObjectName.h"
 #include "wrapper/marker.h"
 
 #include "../base/indexer/haloIndexer.h"
@@ -135,7 +135,7 @@ void RunFunctors<onDevice, Accessor>::iterateFunctor(Functor op, CalcReadInd cal
                                                                                    const size_t elems_y,
                                                                                    const size_t elems_z,
                                                                                    __attribute__((unused)) gpuStream_t stream){
-
+    AutoTimer<onDevice> marker(type_name<Functor>(), "KernelCall");
     dim3 blockDim;
 
     blockDim.x = BlockSize/(elems_y * elems_z);
@@ -148,13 +148,11 @@ void RunFunctors<onDevice, Accessor>::iterateFunctor(Functor op, CalcReadInd cal
 
     if (onDevice) {
 #ifdef __GPUCC__
-        markerBegin(type_name<Functor>(), "KernelCall");
 #ifdef USE_CUDA
         performFunctor<<< gridDim, blockDim,0, stream >>> (getAccessor(), op, calcReadInd, calcWriteInd, elems_x);
 #elif defined USE_HIP
         hipLaunchKernelGGL(performFunctor, dim3(gridDim), dim3(blockDim), 0, stream , getAccessor(), op, calcReadInd, calcWriteInd, elems_x);
 #endif
-        markerEnd();
         gpuError_t gpuErr = gpuGetLastError();
         if (gpuErr)
             GpuError("performFunctor: Failed to launch kernel", gpuErr);
@@ -200,6 +198,7 @@ template<bool onDevice, class Accessor>
 template<size_t Nloops, unsigned BlockSize, typename CalcReadInd, typename CalcWriteInd, typename Functor>
 void RunFunctors<onDevice, Accessor>::iterateFunctorLoop(Functor op,
     CalcReadInd calcReadInd, CalcWriteInd calcWriteInd, const size_t elems_x, const size_t elems_y, const size_t elems_z,__attribute__((unused)) gpuStream_t stream, size_t Nmax) {
+    AutoTimer<onDevice> marker(type_name<Functor>(), "KernelCall");
 
     dim3 blockDim;
 
@@ -220,13 +219,11 @@ void RunFunctors<onDevice, Accessor>::iterateFunctorLoop(Functor op,
     if (onDevice) {
 #ifdef __GPUCC__
 
-        markerBegin(type_name<Functor>(), "KernelCall");
 #ifdef USE_CUDA
         performFunctorLoop<Nloops> <<< gridDim, blockDim, 0, stream >>> (getAccessor(), op, calcReadInd, calcWriteInd, elems_x, Nmax);
 #elif defined USE_HIP
         hipLaunchKernelGGL((performFunctorLoop<Nloops>), dim3(gridDim), dim3(blockDim), 0, stream , getAccessor(), op, calcReadInd, calcWriteInd, elems_x,         Nmax);
 #endif
-        markerEnd();
 
         gpuError_t gpuErr = gpuGetLastError();
         if (gpuErr)
@@ -281,6 +278,7 @@ void RunFunctors<onDevice, Accessor>::iterateWithConstObject(Object ob, CalcRead
         const size_t elems_y,
         const size_t elems_z,
         __attribute__((unused)) gpuStream_t stream ){
+    AutoTimer<onDevice> marker(type_name<Object>(), "KernelCall (const object)");
 
     dim3 blockDim;
 
@@ -294,13 +292,11 @@ void RunFunctors<onDevice, Accessor>::iterateWithConstObject(Object ob, CalcRead
 
     if (onDevice) {
 #ifdef __GPUCC__
-        markerBegin(type_name<Object>(), "KernelCall (const object)");
 #ifdef USE_CUDA
         performCopyConstObject<<< gridDim, blockDim,0, stream >>> (getAccessor(), ob, calcReadInd, calcWriteInd, elems_x);
 #elif defined USE_HIP
         hipLaunchKernelGGL((performCopyConstObject), dim3(gridDim), dim3(blockDim), 0, stream , getAccessor(), ob, calcReadInd, calcWriteInd, elems_x);
 #endif
-        markerEnd();
 
         gpuError_t gpuErr = gpuGetLastError();
         if (gpuErr)
@@ -369,6 +365,7 @@ void iterateFunctorNoReturn(Functor op, CalcReadInd calcReadInd, const size_t el
         const size_t elems_y = 1,
         const size_t elems_z = 1,
         __attribute__((unused)) gpuStream_t stream = (gpuStream_t)nullptr){
+    AutoTimer<onDevice> marker(type_name<Functor>(), "KernelCallNoReturn");
 
     dim3 blockDim;
 
@@ -384,13 +381,11 @@ void iterateFunctorNoReturn(Functor op, CalcReadInd calcReadInd, const size_t el
 #ifdef __GPUCC__
 
 
-        markerBegin(type_name<Functor>(), "KernelCall");
 #ifdef USE_CUDA
         performFunctorNoReturn<<< gridDim, blockDim, 0, stream >>> (op, calcReadInd, elems_x);
 #elif defined USE_HIP
         hipLaunchKernelGGL((performFunctorNoReturn), dim3(gridDim), dim3(blockDim), 0, stream , op, calcReadInd, elems_x);
 #endif
-        markerEnd();
 
         gpuError_t gpuErr = gpuGetLastError();
         if (gpuErr)
@@ -455,6 +450,7 @@ void iterateFunctorComm(Functor op, Accessor acc, CalcReadWriteInd calcReadWrite
                                    const size_t elems_y = 1,
                                    const size_t elems_z = 1,
                                    __attribute__((unused)) gpuStream_t stream = (gpuStream_t)nullptr){
+    AutoTimer<onDevice> marker(type_name<Functor>(), "KernelCallComms");
 
     dim3 blockDim;
 
@@ -469,13 +465,11 @@ void iterateFunctorComm(Functor op, Accessor acc, CalcReadWriteInd calcReadWrite
     if (onDevice) {
 #ifdef __GPUCC__
 
-        markerBegin(type_name<Functor>(), "KernelCall");
 #ifdef USE_CUDA
         performFunctorComm<<< gridDim, blockDim, 0, stream >>> (op, acc, calcReadWriteInd, subHaloSize, elems_x);
 #elif defined USE_HIP
         hipLaunchKernelGGL((performFunctorComm), dim3(gridDim), dim3(blockDim), 0, stream , op, acc, calcReadWriteInd, subHaloSize, elems_x);
 #endif
-        markerEnd();
 
         gpuError_t gpuErr = gpuGetLastError();
         if (gpuErr)

--- a/src/base/runFunctors.h
+++ b/src/base/runFunctors.h
@@ -135,7 +135,7 @@ void RunFunctors<onDevice, Accessor>::iterateFunctor(Functor op, CalcReadInd cal
                                                                                    const size_t elems_y,
                                                                                    const size_t elems_z,
                                                                                    __attribute__((unused)) gpuStream_t stream){
-    AutoTimer<onDevice> marker(type_name<Functor>(), "KernelCall");
+    AutoTimer<onDevice,TRACE> marker(type_name<Functor>(), "KernelCall");
     dim3 blockDim;
 
     blockDim.x = BlockSize/(elems_y * elems_z);
@@ -198,7 +198,7 @@ template<bool onDevice, class Accessor>
 template<size_t Nloops, unsigned BlockSize, typename CalcReadInd, typename CalcWriteInd, typename Functor>
 void RunFunctors<onDevice, Accessor>::iterateFunctorLoop(Functor op,
     CalcReadInd calcReadInd, CalcWriteInd calcWriteInd, const size_t elems_x, const size_t elems_y, const size_t elems_z,__attribute__((unused)) gpuStream_t stream, size_t Nmax) {
-    AutoTimer<onDevice> marker(type_name<Functor>(), "KernelCall");
+    AutoTimer<onDevice,TRACE> marker(type_name<Functor>(), "KernelCall");
 
     dim3 blockDim;
 
@@ -278,7 +278,7 @@ void RunFunctors<onDevice, Accessor>::iterateWithConstObject(Object ob, CalcRead
         const size_t elems_y,
         const size_t elems_z,
         __attribute__((unused)) gpuStream_t stream ){
-    AutoTimer<onDevice> marker(type_name<Object>(), "KernelCall (const object)");
+    AutoTimer<onDevice,TRACE> marker(type_name<Object>(), "KernelCall (const object)");
 
     dim3 blockDim;
 
@@ -365,7 +365,7 @@ void iterateFunctorNoReturn(Functor op, CalcReadInd calcReadInd, const size_t el
         const size_t elems_y = 1,
         const size_t elems_z = 1,
         __attribute__((unused)) gpuStream_t stream = (gpuStream_t)nullptr){
-    AutoTimer<onDevice> marker(type_name<Functor>(), "KernelCallNoReturn");
+    AutoTimer<onDevice,TRACE> marker(type_name<Functor>(), "KernelCallNoReturn");
 
     dim3 blockDim;
 
@@ -450,7 +450,7 @@ void iterateFunctorComm(Functor op, Accessor acc, CalcReadWriteInd calcReadWrite
                                    const size_t elems_y = 1,
                                    const size_t elems_z = 1,
                                    __attribute__((unused)) gpuStream_t stream = (gpuStream_t)nullptr){
-    AutoTimer<onDevice> marker(type_name<Functor>(), "KernelCallComms");
+    AutoTimer<onDevice,TRACE> marker(type_name<Functor>(), "KernelCallComms");
 
     dim3 blockDim;
 

--- a/src/base/stopWatch.h
+++ b/src/base/stopWatch.h
@@ -149,13 +149,13 @@ class StopWatch {
 
     [[nodiscard]] std::string autoFormat() const {
         if(days() > 2){
-            return sformat("%.0fd %.0fh %.2fmin", days(), hours(), std::fmod(minutes(),60.0));
+            return sformat("%.0fd %.0fh %.2fmin", std::floor(days()), std::floor(hours()), std::fmod(minutes(),60.0));
         }
         else if(hours() > 2){
-            return sformat("%.0fh %.2fmin", hours(), std::fmod(minutes(),60.0));
+            return sformat("%.0fh %.2fmin", std::floor(hours()), std::fmod(minutes(),60.0));
         }
         else if(minutes() > 2){
-            return sformat("%.0fmin %.3fs", minutes(), std::fmod(seconds(),60.0));
+            return sformat("%.0fmin %.3fs", std::floor(minutes()), std::fmod(seconds(),60.0));
         }
         else if(seconds() > 2){
             return sformat("%.3fs", seconds());

--- a/src/base/utilities/parseObjectName.h
+++ b/src/base/utilities/parseObjectName.h
@@ -8,7 +8,7 @@
 template <std::size_t...Idxs>
 constexpr auto substring_as_array(std::string_view str, std::index_sequence<Idxs...>)
 {
-  return std::array{str[Idxs]..., '\n'};
+  return std::array{str[Idxs]..., ' '};
 }
 
 template <typename T>

--- a/src/base/wrapper/marker.h
+++ b/src/base/wrapper/marker.h
@@ -28,24 +28,30 @@ inline void markerEnd(){
 #endif
 }
 
-template<bool onDevice>
+template<bool onDevice, LogLevel level>
 class AutoTimer {
     StopWatch<onDevice> internalTimer;
     std::string_view marker_name;
     std::string_view group_name;
+    bool timer_started = false;
+    bool marker_started = false;
     public:
-    AutoTimer<onDevice>(std::string_view mn, std::string_view gn) : marker_name(mn), group_name(gn) {
-        if (rootLogger.getVerbosity() == TRACE) {
-        internalTimer.start();
-        markerBegin(marker_name, group_name);
+    AutoTimer<onDevice,level>(std::string_view mn, std::string_view gn) : marker_name(mn), group_name(gn) {
+        if (rootLogger.getVerbosity() == level) {
+            timer_started=true;
+            marker_started=true;
+            internalTimer.start();
+            markerBegin(marker_name, group_name);
         }
     }
 
-    ~AutoTimer<onDevice>(){
-        if (rootLogger.getVerbosity() == TRACE) {
-        markerEnd();
-        internalTimer.stop();
-        rootLogger.trace(std::string(group_name), ": ", std::string(marker_name), "took ", internalTimer);
+    ~AutoTimer<onDevice,level>(){
+        if (marker_started) {
+            markerEnd();
+        }
+        if (timer_started) {
+            internalTimer.stop();
+            rootLogger.template message<level>(std::string(group_name), ": ", std::string(marker_name), "took ", internalTimer);
         }
     }
 };

--- a/src/base/wrapper/marker.h
+++ b/src/base/wrapper/marker.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <string_view>
 #include "gpu_wrapper.h"
+#include "../stopWatch.h"
+#include "../utilities/parseObjectName.h"
 
 inline void markerBegin(std::string_view marker_name, std::string_view group_name){
 #ifdef USE_MARKER
@@ -25,3 +27,25 @@ inline void markerEnd(){
     #endif
 #endif
 }
+
+template<bool onDevice>
+class AutoTimer {
+    StopWatch<onDevice> internalTimer;
+    std::string_view marker_name;
+    std::string_view group_name;
+    public:
+    AutoTimer<onDevice>(std::string_view mn, std::string_view gn) : marker_name(mn), group_name(gn) {
+        if (rootLogger.getVerbosity() == TRACE) {
+        internalTimer.start();
+        markerBegin(marker_name, group_name);
+        }
+    }
+
+    ~AutoTimer<onDevice>(){
+        if (rootLogger.getVerbosity() == TRACE) {
+        markerEnd();
+        internalTimer.stop();
+        rootLogger.trace(std::string(group_name), ": ", std::string(marker_name), "took ", internalTimer);
+        }
+    }
+};

--- a/src/testing/main_stopwatch.cpp
+++ b/src/testing/main_stopwatch.cpp
@@ -1,0 +1,32 @@
+#include "../simulateqcd.h"
+#include <chrono>
+#include<thread>
+
+int main(int argc, char **argv) {
+    stdLogger.setVerbosity(DEBUG);
+
+    
+    LatticeParameters param;
+    const int  LatDim[]   = {20,20,20,20};
+    const int  NodeDim[]  = {1 ,1 ,1 ,1};
+    const int HaloDepth = 1;
+    param.latDim.set(LatDim);
+    param.nodeDim.set(NodeDim);
+    CommunicationBase commBase(&argc, &argv);
+    commBase.init(param.nodeDim());
+    initIndexer(HaloDepth,param,commBase);
+
+    StopWatch<true> timer;
+
+    timer.start();
+
+    std::this_thread::sleep_for(std::chrono::minutes(2));
+    std::this_thread::sleep_for(std::chrono::seconds(50));
+
+    timer.stop();
+
+    rootLogger.info("Time elapsed: ", timer);
+
+    return 0;
+    
+}


### PR DESCRIPTION
Adding a new AutoTimer class that adds roctx/nvtx markers and timing to every kernel launch issued through our runFunctor interface. Additionally, arbitrary scopes inside the code can be marked and timed by simply creating an AutoTimer object in that scope. To activate timing and markers, the enclosing logLevel of the rootLogger needs to be set to "TRACE".