### PR TITLE
Fix compute mode query for CUDA 13

### DIFF
--- a/src/base/communication/neighborInfo.h
+++ b/src/base/communication/neighborInfo.h
@@ -427,12 +427,20 @@ inline void NeighborInfo::exchangeProcessInfo() {
 
 inline bool NeighborInfo::IsGPUCapableP2P() const {
     // This requires two processes accessing each device, so we need
-    // to ensure exclusive or prohibited mode is not set
-    if (myProp.computeMode != gpuComputeModeDefault) {
-        throw std::runtime_error(stdLogger.fatal("Device ", myProp.name, " is in an unsupported compute mode (exclusive or prohibited mode is NOT allowed)"));
+    // to ensure exclusive or prohibited mode is not set.
+    int computeMode = 0;
+    gpuError_t gpuErr = gpuDeviceGetAttribute(&computeMode, gpuDevAttrComputeMode, myInfo.deviceRank);
+    if (gpuErr != gpuSuccess) {
+        GpuError("neighborInfo.h: gpuDeviceGetAttribute(compute mode) failed:", gpuErr);
     }
-    return (bool) (myProp.major >= 2);
 
+    if (computeMode != gpuComputeModeDefault) {
+        throw std::runtime_error(stdLogger.fatal(
+            "Device ", myProp.name,
+            " is in an unsupported compute mode (exclusive or prohibited mode is NOT allowed)"));
+    }
+
+    return (bool) (myProp.major >= 2);
 }
 
 

--- a/src/base/wrapper/gpu_wrapper.h
+++ b/src/base/wrapper/gpu_wrapper.h
@@ -28,6 +28,8 @@
 #define gpuStream_t                      cudaStream_t
 
 #define gpuComputeModeDefault            cudaComputeModeDefault
+#define gpuDeviceGetAttribute            cudaDeviceGetAttribute
+#define gpuDevAttrComputeMode            cudaDevAttrComputeMode
 #define gpuDeviceCanAccessPeer           cudaDeviceCanAccessPeer
 #define gpuDeviceSynchronize             cudaDeviceSynchronize
 #define gpuEventCreate                   cudaEventCreate
@@ -105,6 +107,8 @@
 #define gpuStream_t                      hipStream_t
 
 #define gpuComputeModeDefault            hipComputeModeDefault
+#define gpuDeviceGetAttribute            hipDeviceGetAttribute
+#define gpuDevAttrComputeMode            hipDeviceAttributeComputeMode
 #define gpuDeviceCanAccessPeer           hipDeviceCanAccessPeer
 #define gpuDeviceSynchronize             hipDeviceSynchronize
 #define gpuEventCreate                   hipEventCreate


### PR DESCRIPTION
CUDA 13 removes the deprecated `computeMode` member from `cudaDeviceProp`,
which causes compilation to fail in `NeighborInfo::IsGPUCapableP2P()`.

This replaces direct access to `cudaDeviceProp::computeMode` with the
supported device-attribute query API and adds the corresponding CUDA/HIP
aliases to `gpu_wrapper.h`.

The replacement API is also available in CUDA 12.x, so this avoids
CUDA-version-specific preprocessor logic while retaining compatibility with
older CUDA toolkits.

Validation:
- Full SIMULATeQCD build with CUDA 13.0.48
- GCC 14.3.0 and ParaStationMPI 5.13.0-1
- NVIDIA GH200 / sm_90 on JUPITER
- `simpleFunctorTest` executed successfully on a GH200
- All `simpleFunctorTest` checks passed with exit code 0

The same compatibility change also allows the current `Deflation` branch to
build completely with CUDA 13.

No behavioral change is intended beyond replacing the removed device-property
access with the supported runtime attribute query.