### PR TITLE
Fix compute mode query for CUDA 13

### DIFF
--- a/src/base/communication/neighborInfo.h
+++ b/src/base/communication/neighborInfo.h
@@ -427,12 +427,20 @@ inline void NeighborInfo::exchangeProcessInfo() {
 
 inline bool NeighborInfo::IsGPUCapableP2P() const {
     // This requires two processes accessing each device, so we need
-    // to ensure exclusive or prohibited mode is not set
-    if (myProp.computeMode != gpuComputeModeDefault) {
-        throw std::runtime_error(stdLogger.fatal("Device ", myProp.name, " is in an unsupported compute mode (exclusive or prohibited mode is NOT allowed)"));
+    // to ensure exclusive or prohibited mode is not set.
+    int computeMode = 0;
+    gpuError_t gpuErr = gpuDeviceGetAttribute(&computeMode, gpuDevAttrComputeMode, myInfo.deviceRank);
+    if (gpuErr != gpuSuccess) {
+        GpuError("neighborInfo.h: gpuDeviceGetAttribute(compute mode) failed:", gpuErr);
     }
-    return (bool) (myProp.major >= 2);
 
+    if (computeMode != gpuComputeModeDefault) {
+        throw std::runtime_error(stdLogger.fatal(
+            "Device ", myProp.name,
+            " is in an unsupported compute mode (exclusive or prohibited mode is NOT allowed)"));
+    }
+
+    return (bool) (myProp.major >= 2);
 }
 
 

--- a/src/base/wrapper/gpu_wrapper.h
+++ b/src/base/wrapper/gpu_wrapper.h
@@ -28,6 +28,8 @@
 #define gpuStream_t                      cudaStream_t
 
 #define gpuComputeModeDefault            cudaComputeModeDefault
+#define gpuDeviceGetAttribute            cudaDeviceGetAttribute
+#define gpuDevAttrComputeMode            cudaDevAttrComputeMode
 #define gpuDeviceCanAccessPeer           cudaDeviceCanAccessPeer
 #define gpuDeviceSynchronize             cudaDeviceSynchronize
 #define gpuEventCreate                   cudaEventCreate
@@ -105,6 +107,8 @@
 #define gpuStream_t                      hipStream_t
 
 #define gpuComputeModeDefault            hipComputeModeDefault
+#define gpuDeviceGetAttribute            hipDeviceGetAttribute
+#define gpuDevAttrComputeMode            hipDeviceAttributeComputeMode
 #define gpuDeviceCanAccessPeer           hipDeviceCanAccessPeer
 #define gpuDeviceSynchronize             hipDeviceSynchronize
 #define gpuEventCreate                   hipEventCreate


### PR DESCRIPTION
Applies the same CUDA 13 compatibility fix as the corresponding PR against `main` to the `Deflation` branch.

CUDA 13 removes the deprecated `computeMode` member from `cudaDeviceProp`, causing compilation to fail in `NeighborInfo::IsGPUCapableP2P()`.

This replaces the direct structure-member access with the supported `gpuDeviceGetAttribute(..., gpuDevAttrComputeMode, ...)` query through the SIMULATeQCD GPU wrapper, with the corresponding CUDA and HIP aliases added to `gpu_wrapper.h`.

The replacement API is also available in CUDA 12.x, so this avoids CUDA-version-specific conditional compilation while retaining compatibility with older CUDA toolkits.

### Validation

* Base: `befd2d7` (merge of PR #166)
* Full SIMULATeQCD `Deflation` build completed successfully
* CUDA 13.0.48
* GCC 14.3.0
* ParaStationMPI 5.13.0-1
* NVIDIA GH200 / `sm_90` on JUPITER

No behavioral change is intended beyond replacing the removed device-property access with the supported runtime attribute query.

This PR mirrors the CUDA 13 compatibility fix in #167.

